### PR TITLE
Feature: Form Output Task

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -5,6 +5,7 @@
         public static class Features
         {
             public const string Export = "Etch.OrchardCore.Workflows.Export";
+            public const string FormOutput = "Etch.OrchardCore.Workflows.FormOutput";
             public const string Validation = "Etch.OrchardCore.Workflows.Validation";
         }
     }

--- a/FormOutput/Startup.cs
+++ b/FormOutput/Startup.cs
@@ -1,0 +1,21 @@
+﻿using Etch.OrchardCore.Workflows.FormOutput.Workflows.Activities;
+using Etch.OrchardCore.Workflows.FormOutput.Workflows.Drivers;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Modules;
+using OrchardCore.Workflows.Helpers;
+
+namespace Etch.OrchardCore.Workflows.FormOutput
+{
+    [Feature(Constants.Features.FormOutput)]
+    public class Startup : StartupBase
+    {
+        #region Implementation
+
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddActivity<FormOutputTask, FormOutputTaskDriver>();
+        }
+
+        #endregion Implementation
+    }
+}

--- a/FormOutput/Workflows/Activities/FormOutputTask.cs
+++ b/FormOutput/Workflows/Activities/FormOutputTask.cs
@@ -1,0 +1,105 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Localization;
+using OrchardCore.Workflows.Abstractions.Models;
+using OrchardCore.Workflows.Activities;
+using OrchardCore.Workflows.Models;
+using System.Collections.Generic;
+
+namespace Etch.OrchardCore.Workflows.FormOutput.Workflows.Activities
+{
+    public class FormOutputTask : TaskActivity
+    {
+        #region Constants
+
+        private const string OutcomeDone = "Done";
+
+        #endregion Constants
+
+        #region Dependencies
+
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        #region Properties
+
+        public IStringLocalizer T { get; set; }
+
+        #endregion Properties
+
+        #endregion Dependencies
+
+        #region Constructor
+
+        public FormOutputTask(
+            IHttpContextAccessor httpContextAccessor,
+            IStringLocalizer<FormOutputTask> stringLocalizer
+            )
+        {
+            _httpContextAccessor = httpContextAccessor;
+            T = stringLocalizer;
+        }
+
+        #endregion Constructor
+
+        #region Implementation
+
+        #region Properties
+
+        #region Public
+
+        public override string Name => nameof(FormOutputTask);
+
+        public override LocalizedString Category => T["Primitives"];
+
+        #endregion Public
+
+        #region Input
+
+        public string Prefix
+        {
+            get => GetProperty<string>();
+            set => SetProperty(value);
+        }
+
+        #endregion Input
+
+        #endregion Properties
+
+        #region Actions
+
+        public override bool CanExecute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+        {
+            return _httpContextAccessor.HttpContext?.Request?.Form != null;
+        }
+
+        public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+        {
+            var form = _httpContextAccessor.HttpContext?.Request?.Form;
+
+            if (form == null)
+            {
+                return Outcomes(OutcomeDone);
+            }
+
+            foreach (var field in form.Keys)
+            {
+                var outputKey = field;
+                if (!string.IsNullOrWhiteSpace(Prefix))
+                {
+                    outputKey = Prefix + outputKey;
+                }
+                workflowContext.Output[outputKey] = string.Join(", ", form[field].ToArray());
+            }
+
+            return Outcomes(OutcomeDone);
+        }
+
+        public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+        {
+            return Outcomes(T[OutcomeDone]);
+        }
+
+        #endregion Actions
+
+        #endregion Implementation
+    }
+}

--- a/FormOutput/Workflows/Drivers/FormOutputTaskDriver.cs
+++ b/FormOutput/Workflows/Drivers/FormOutputTaskDriver.cs
@@ -1,0 +1,11 @@
+﻿using Etch.OrchardCore.Workflows.FormOutput.Workflows.Activities;
+using Etch.OrchardCore.Workflows.FormOutput.Workflows.ViewModels;
+using OrchardCore.Workflows.Display;
+
+namespace Etch.OrchardCore.Workflows.FormOutput.Workflows.Drivers
+{
+    public class FormOutputTaskDriver : ActivityDisplayDriver<FormOutputTask, FormOutputTaskViewModel>
+    {
+        
+    }
+}

--- a/FormOutput/Workflows/Drivers/FormOutputTaskDriver.cs
+++ b/FormOutput/Workflows/Drivers/FormOutputTaskDriver.cs
@@ -6,6 +6,16 @@ namespace Etch.OrchardCore.Workflows.FormOutput.Workflows.Drivers
 {
     public class FormOutputTaskDriver : ActivityDisplayDriver<FormOutputTask, FormOutputTaskViewModel>
     {
-        
+        protected override void EditActivity(FormOutputTask activity, FormOutputTaskViewModel model)
+        {
+            model.Ignored = activity.Ignored;
+            model.Prefix = activity.Prefix;
+        }
+
+        protected override void UpdateActivity(FormOutputTaskViewModel model, FormOutputTask activity)
+        {
+            activity.Ignored = model.Ignored;
+            activity.Prefix = model.Prefix;
+        }
     }
 }

--- a/FormOutput/Workflows/ViewModels/FormOutputTaskViewModel.cs
+++ b/FormOutput/Workflows/ViewModels/FormOutputTaskViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Etch.OrchardCore.Workflows.FormOutput.Workflows.ViewModels
+{
+    public class FormOutputTaskViewModel
+    {
+        public string Prefix { get; set; }
+    }
+}

--- a/FormOutput/Workflows/ViewModels/FormOutputTaskViewModel.cs
+++ b/FormOutput/Workflows/ViewModels/FormOutputTaskViewModel.cs
@@ -2,6 +2,7 @@
 {
     public class FormOutputTaskViewModel
     {
+        public string Ignored { get; set; }
         public string Prefix { get; set; }
     }
 }

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -19,6 +19,14 @@ using OrchardCore.Modules.Manifest;
 )]
 
 [assembly: Feature(
+    Id = Constants.Features.FormOutput,
+    Name = "Form Output",
+    Category = "Workflows",
+    Dependencies = new[] { "OrchardCore.Workflows" },
+    Description = "Provides a task for writing all form fields into Output properties."
+)]
+
+[assembly: Feature(
     Id = Constants.Features.Validation,
     Name = "Validation",
     Category = "Workflows",

--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ This feature adds useful validation tasks for Workflows.
 #### Validate Multiple Fields
 
 Allows the user to specify multiple field names which will all be validated for not having empty content. The task provides `Valid` and `Invalid` outcomes as well as `Done` and will update the `ModelState` in the same way as the stock Orchard Core validate tasks.
+
+### Form Output
+
+This feature provides a task `Set Form Outputs` which will send all entries from the form to the `Output` of the workflow with the same names as their form `input`s.
+
+It has an option for `Prefix` which will prepend the entered string to the output keys.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This module provides a set features which operate independantly of each other.
 
 ### Export Workflows
 
-When enabled this feature will make a new "Export Workflows" option available in the admin menu for users with the `Export workflow data` permission (also provided by this feature).
+Adds "Export Workflows" option in the admin menu for users with the `Export workflow data` permission.
 
 The "Export Workflows" page displays a list of workflows similar to what is seen when accessing the main "Workflows" route, selecting "Export" on one of these will take the user to a "Preview" page showing them how many instances the chosen workflow has and a preview of the Outputs the latest one has.
 
@@ -36,8 +36,14 @@ Allows the user to specify multiple field names which will all be validated for 
 
 ### Form Output
 
-This feature provides a task `Set Form Outputs` which will send all entries from the form to the `Output` of the workflow with the same names as their form `input`s.
+Provides a task `Set Form Outputs` which will send all entries from the form to the `Output` of the workflow with the same names as their form `input`s.
 
-It has an option for `Prefix` which will prepend the entered string to the output keys.
+The following options are available:
 
-It also has an option for `Ignored` allowing to the user to specify fields which should not be added to the `Output`. e.g.: form validation token.
+#### Prefix
+
+Prepend the entered string to the output keys.
+
+#### Ignored
+
+Allows the user to specify fields which should not be added to the `Output`. e.g.: form validation token.

--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ Allows the user to specify multiple field names which will all be validated for 
 This feature provides a task `Set Form Outputs` which will send all entries from the form to the `Output` of the workflow with the same names as their form `input`s.
 
 It has an option for `Prefix` which will prepend the entered string to the output keys.
+
+It also has an option for `Ignored` allowing to the user to specify fields which should not be added to the `Output`. e.g.: form validation token.

--- a/Views/Items/FormOutputTask.Fields.Design.cshtml
+++ b/Views/Items/FormOutputTask.Fields.Design.cshtml
@@ -1,0 +1,8 @@
+﻿@model ActivityViewModel<FormOutputTask>
+@using OrchardCore.Workflows.Helpers
+@using OrchardCore.Workflows.ViewModels
+@using Etch.OrchardCore.Workflows.FormOutput.Workflows.Activities
+<header>
+    <h4><i class="fas fa-sign-out-alt"></i>@Model.Activity.GetTitleOrDefault(() => T["Form Outputs"])</h4>
+</header>
+<em>Send all form entries to Output</em>

--- a/Views/Items/FormOutputTask.Fields.Design.cshtml
+++ b/Views/Items/FormOutputTask.Fields.Design.cshtml
@@ -5,4 +5,4 @@
 <header>
     <h4><i class="fas fa-sign-out-alt"></i>@Model.Activity.GetTitleOrDefault(() => T["Form Outputs"])</h4>
 </header>
-<em>Send all form entries to Output</em>
+<em>@T["Send all form entries to Output."]</em>

--- a/Views/Items/FormOutputTask.Fields.Edit.cshtml
+++ b/Views/Items/FormOutputTask.Fields.Edit.cshtml
@@ -3,14 +3,14 @@
 
 <fieldset class="form-group" asp-validation-class-for="Ignored">
     <label asp-for="Ignored">@T["Ignored fields"]</label>
-    <input asp-for="Ignored" class="form-control" autofocus="autofocus" />
+    <input asp-for="Ignored" class="form-control" />
     <span asp-validation-for="Ignored"></span>
     <span class="hint">@T["Comma separated list of field names which should not be copied to the Output."]</span>
 </fieldset>
 
 <fieldset class="form-group" asp-validation-class-for="Prefix">
     <label asp-for="Prefix">@T["Prefix"]</label>
-    <input asp-for="Prefix" class="form-control" autofocus="autofocus" />
+    <input asp-for="Prefix" class="form-control" />
     <span asp-validation-for="Prefix"></span>
     <span class="hint">@T["Prefix for form entries on the output (e.g. the output name will be '<Value entered above>InputName')."]</span>
 </fieldset>

--- a/Views/Items/FormOutputTask.Fields.Edit.cshtml
+++ b/Views/Items/FormOutputTask.Fields.Edit.cshtml
@@ -1,6 +1,13 @@
 ﻿@using Etch.OrchardCore.Workflows.FormOutput.Workflows.ViewModels;
 @model FormOutputTaskViewModel
 
+<fieldset class="form-group" asp-validation-class-for="Ignored">
+    <label asp-for="Ignored">@T["Ignored fields"]</label>
+    <input asp-for="Ignored" class="form-control" autofocus="autofocus" />
+    <span asp-validation-for="Ignored"></span>
+    <span class="hint">@T["Comma separated list of field names which should not be copied to the Output."]</span>
+</fieldset>
+
 <fieldset class="form-group" asp-validation-class-for="Prefix">
     <label asp-for="Prefix">@T["Prefix"]</label>
     <input asp-for="Prefix" class="form-control" autofocus="autofocus" />

--- a/Views/Items/FormOutputTask.Fields.Edit.cshtml
+++ b/Views/Items/FormOutputTask.Fields.Edit.cshtml
@@ -1,0 +1,9 @@
+﻿@using Etch.OrchardCore.Workflows.FormOutput.Workflows.ViewModels;
+@model FormOutputTaskViewModel
+
+<fieldset class="form-group" asp-validation-class-for="Prefix">
+    <label asp-for="Prefix">@T["Prefix"]</label>
+    <input asp-for="Prefix" class="form-control" autofocus="autofocus" />
+    <span asp-validation-for="Prefix"></span>
+    <span class="hint">@T["Prefix for form entries on the output (e.g. the output name will be '<Value entered above>InputName')."]</span>
+</fieldset>

--- a/Views/Items/FormOutputTask.Fields.Thumbnail.cshtml
+++ b/Views/Items/FormOutputTask.Fields.Thumbnail.cshtml
@@ -1,0 +1,2 @@
+﻿<h4 class="card-title"><i class="fa fa-sign-out-alt"></i>@T["Form Outputs"]</h4>
+<p>@T["Put all Form field values into Output."]</p>


### PR DESCRIPTION
This feature provides a task `Set Form Outputs` which will send all entries from the form to the `Output` of the workflow with the same names as their form inputs.

It has an option for `Prefix` which will prepend the entered string to the output keys.

It also has an option for `Ignored` allowing to the user to specify fields which should not be added to the `Output`. e.g.: form validation token.