### PR TITLE
Upgrade to Orchard Core RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: csharp
 mono: none
 dist: bionic
-dotnet: 2.2.100
-
+dotnet: 3.0
 install:
 - dotnet restore
 

--- a/Etch.OrchardCore.Workflows.csproj
+++ b/Etch.OrchardCore.Workflows.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.1.0-beta</Version>
+    <Version>0.2.0-rc1</Version>
     <PackageId>Etch.OrchardCore.Workflows</PackageId>
     <Title>Etch Workflows</Title>
     <Authors>Etch UK Ltd.</Authors>
@@ -13,19 +14,20 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="12.1.2" />
-    <PackageReference Include="OrchardCore.Admin.Abstractions" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.DisplayManagement" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.Email" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.Navigation" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.ResourceManagement" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-beta3-71077" />
+    <PackageReference Include="OrchardCore.Admin.Abstractions" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.DisplayManagement" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Email" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Email.Abstractions" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Navigation" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.ResourceManagement" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Templates" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Workflows" Version="1.0.0-rc1-10004" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="OrchardCore.Templates" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.Workflows" Version="1.0.0-beta3-71077" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>

--- a/Export/Permissions.cs
+++ b/Export/Permissions.cs
@@ -1,5 +1,7 @@
 ﻿using OrchardCore.Security.Permissions;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Etch.OrchardCore.Workflows.Export
 {
@@ -10,7 +12,6 @@ namespace Etch.OrchardCore.Workflows.Export
         public static readonly Permission ExportWorkflows = new Permission("ExportWorkflows", "Export workflow data");
 
         #endregion Permissions
-
 
         #region Implementation
 
@@ -26,9 +27,9 @@ namespace Etch.OrchardCore.Workflows.Export
             };
         }
 
-        public IEnumerable<Permission> GetPermissions()
+        public Task<IEnumerable<Permission>> GetPermissionsAsync()
         {
-            return new[] { ExportWorkflows };
+            return Task.FromResult(new[] { ExportWorkflows }.AsEnumerable());
         }
 
         #endregion Implementation

--- a/Export/Startup.cs
+++ b/Export/Startup.cs
@@ -15,19 +15,19 @@ namespace Etch.OrchardCore.Workflows.Export
 
         #region Implementation
 
-        public override void Configure(IApplicationBuilder app, IRouteBuilder routes, IServiceProvider serviceProvider)
+        public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
         {
-            routes.MapAreaRoute(
+            routes.MapAreaControllerRoute(
                 name: "WorkflowExport",
                 areaName: "Etch.OrchardCore.Workflows",
-                template: "Admin/Workflows/Export",
+                pattern: "Admin/Workflows/Export",
                 defaults: new { controller = "Export", action = "Index" }
             );
 
-            routes.MapAreaRoute(
+            routes.MapAreaControllerRoute(
                 name: "WorkflowExportPreview",
                 areaName: "Etch.OrchardCore.Workflows",
-                template: "Admin/Workflows/Export/{id}/Preview",
+                pattern: "Admin/Workflows/Export/{id}/Preview",
                 defaults: new { controller = "Export", action = "Preview" }
             );
         }

--- a/FormOutput/Workflows/Activities/FormOutputTask.cs
+++ b/FormOutput/Workflows/Activities/FormOutputTask.cs
@@ -48,6 +48,8 @@ namespace Etch.OrchardCore.Workflows.FormOutput.Workflows.Activities
 
         #region Public
 
+        public override LocalizedString DisplayText => T["Form Output Task"];
+
         public override string Name => nameof(FormOutputTask);
 
         public override LocalizedString Category => T["Primitives"];
@@ -59,13 +61,13 @@ namespace Etch.OrchardCore.Workflows.FormOutput.Workflows.Activities
         public string Ignored
         {
             get => GetProperty<string>();
-            set => SetProperty(value);
+            set => SetProperty(value ?? string.Empty);
         }
 
         public string Prefix
         {
             get => GetProperty<string>();
-            set => SetProperty(value);
+            set => SetProperty(value ?? string.Empty);
         }
 
         #endregion Input

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -6,7 +6,7 @@ using OrchardCore.Modules.Manifest;
     Category = "Workflows",
     Description = "Provides useful workflow tasks and events",
     Name = "Etch Workflows",
-    Version = "0.1.0",
+    Version = "0.2.0",
     Website = "https://etchuk.com"
 )]
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Module for [Orchard Core](https://github.com/OrchardCMS/OrchardCore) provides us
 
 ## Orchard Core Reference
 
-This module is referencing the beta 3 build of Orchard Core ([`1.0.0-beta3-71077`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-beta3-71077)).
+This module is referencing the RC1 build of Orchard Core ([`1.0.0-rc1-10004`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-rc1-10004)).
 
 ## Installing
 

--- a/TemplateEmail/Workflows/Activities/TemplateEmailTask.cs
+++ b/TemplateEmail/Workflows/Activities/TemplateEmailTask.cs
@@ -8,7 +8,6 @@ using OrchardCore.Workflows.Activities;
 using OrchardCore.Workflows.Models;
 using OrchardCore.Workflows.Services;
 using System.Collections.Generic;
-using System.Net.Mail;
 using System.Threading.Tasks;
 
 namespace Etch.OrchardCore.Workflows.TemplateEmail.Workflows.Activities
@@ -38,6 +37,8 @@ namespace Etch.OrchardCore.Workflows.TemplateEmail.Workflows.Activities
         }
 
         private IStringLocalizer T { get; }
+
+        public override LocalizedString DisplayText => T["Template Email Task"];
         public override string Name => nameof(TemplateEmailTask);
         public override LocalizedString Category => T["Messaging"];
 
@@ -110,11 +111,11 @@ namespace Etch.OrchardCore.Workflows.TemplateEmail.Workflows.Activities
                 IsBodyHtml = IsBodyHtml
             };
 
-            message.To.Add(recipientsTask.Result.Trim());
+            message.To = recipientsTask.Result.Trim();
 
             if (!string.IsNullOrWhiteSpace(senderTask.Result))
             {
-                message.From = new MailAddress(senderTask.Result.Trim());
+                message.From = senderTask.Result.Trim();
             }
 
             var result = await _smtpService.SendAsync(message);

--- a/Validation/Workflows/Activities/ValidateMatchingTask.cs
+++ b/Validation/Workflows/Activities/ValidateMatchingTask.cs
@@ -52,6 +52,8 @@ namespace Etch.OrchardCore.Workflows.Validation.Workflows.Activities
 
         #region Properties
 
+        public override LocalizedString DisplayText => T["Validate Matching Task"];
+
         public override string Name => nameof(ValidateMatchingTask);
 
         public override LocalizedString Category => T["Validation"];

--- a/Validation/Workflows/Activities/ValidateMultipleTask.cs
+++ b/Validation/Workflows/Activities/ValidateMultipleTask.cs
@@ -51,6 +51,8 @@ namespace Etch.OrchardCore.Workflows.Validation.Workflows.Activities
 
         #region Properties
 
+        public override LocalizedString DisplayText => T["Validate Multiple Task"];
+
         public override string Name => nameof(ValidateMultipleTask);
 
         public override LocalizedString Category => T["Validation"];

--- a/Validation/Workflows/Activities/ValidateRequiredWhenCheckedTask.cs
+++ b/Validation/Workflows/Activities/ValidateRequiredWhenCheckedTask.cs
@@ -51,6 +51,7 @@ namespace Etch.OrchardCore.Workflows.Validation.Workflows.Activities
 
         #region Properties
 
+        public override LocalizedString DisplayText => T["Validate Required When Checked Task"];
         public override string Name => nameof(ValidateRequiredWhenCheckedTask);
 
         public override LocalizedString Category => T["Validation"];

--- a/azure-pipelines-prerelease.yml
+++ b/azure-pipelines-prerelease.yml
@@ -1,5 +1,6 @@
 pool:
-  name: Hosted VS2017
+  vmImage: 'windows-2019'
+  
 variables:
   BuildConfiguration: 'Release'
 

--- a/azure-pipelines-stable.yml
+++ b/azure-pipelines-stable.yml
@@ -1,5 +1,6 @@
 pool:
-  name: Hosted VS2017
+  vmImage: 'windows-2019'
+  
 variables:
   BuildConfiguration: 'Release'
 

--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <activePackageSource>
-    <add key="All" value="(Aggregate source)" />
-  </activePackageSource>
-</configuration>


### PR DESCRIPTION
- Change target framework to .NET core 3.0
- Add `AddRazorSupportForMvc` to signify class library contains UI
components for MVC
- Update all Orchard Core dependencies to point to rc1 release
- Swap `Microsoft.AspNetCore` references for `FrameworkReference`
- Update Azure pipeline build script to use .NET core 3.0
- Remove redundant NuGet config
- Update permission providers to be async
- Update `Startup` for API change on `ConfigureServices`
- Fix tasks not implementing `DisplayText` on `IActivity`
- Update Travis build script to use .NET core 3.0
- Update docs for Orchard Core reference
- Bump version number and update suffix to "rc1"