### PR TITLE
Upgrade to RC2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: csharp
 mono: none
 dist: bionic
-dotnet: 3.0
+dotnet: 3.1
+
 install:
 - dotnet restore
 

--- a/Etch.OrchardCore.Workflows.csproj
+++ b/Etch.OrchardCore.Workflows.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.2.0-rc1</Version>
+    <Version>0.3.0-rc2</Version>
     <PackageId>Etch.OrchardCore.Workflows</PackageId>
     <Title>Etch Workflows</Title>
     <Authors>Etch UK Ltd.</Authors>
@@ -14,16 +14,16 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="12.1.2" />
-    <PackageReference Include="OrchardCore.Admin.Abstractions" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.DisplayManagement" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.Email" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.Email.Abstractions" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.Navigation" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.ResourceManagement" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.Templates" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.Workflows" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Admin.Abstractions" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.DisplayManagement" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.Email" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.Email.Abstractions" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.Navigation" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.ResourceManagement" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.Templates" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.Workflows" Version="1.0.0-rc2-13450" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -6,7 +6,7 @@ using OrchardCore.Modules.Manifest;
     Category = "Workflows",
     Description = "Provides useful workflow tasks and events",
     Name = "Etch Workflows",
-    Version = "0.2.0",
+    Version = "0.3.0",
     Website = "https://etchuk.com"
 )]
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Module for [Orchard Core](https://github.com/OrchardCMS/OrchardCore) provides us
 
 ## Orchard Core Reference
 
-This module is referencing the RC1 build of Orchard Core ([`1.0.0-rc1-10004`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-rc1-10004)).
+This module is referencing the RC2 build of Orchard Core ([`1.0.0-rc2-13450`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-rc2-13450)).
 
 ## Installing
 

--- a/TemplateEmail/Workflows/Activities/TemplateEmailTask.cs
+++ b/TemplateEmail/Workflows/Activities/TemplateEmailTask.cs
@@ -86,10 +86,10 @@ namespace Etch.OrchardCore.Workflows.TemplateEmail.Workflows.Activities
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            var senderTask = _expressionEvaluator.EvaluateAsync(Sender, workflowContext);
-            var recipientsTask = _expressionEvaluator.EvaluateAsync(Recipients, workflowContext);
-            var subjectTask = _expressionEvaluator.EvaluateAsync(Subject, workflowContext);
-            var body = await _expressionEvaluator.EvaluateAsync(Body, workflowContext);
+            var senderTask = _expressionEvaluator.EvaluateAsync(Sender, workflowContext, null);
+            var recipientsTask = _expressionEvaluator.EvaluateAsync(Recipients, workflowContext, null);
+            var subjectTask = _expressionEvaluator.EvaluateAsync(Subject, workflowContext, null);
+            var body = await _expressionEvaluator.EvaluateAsync(Body, workflowContext, null);
 
             if (!string.IsNullOrEmpty(TemplateName))
             {


### PR DESCRIPTION
- Update target framework to 3.1
- Update Orchard Core references to RC2
- Update travis build to target 3.1
- Fix compile errors caused by API changes
- Update version to `v0.3.0-rc2`